### PR TITLE
fix types config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./index.mjs",
   "module": "./index.mjs",
-  "types": "./type/index.d.ts",
+  "types": "./types/index.d.ts",
   "sideEffects": false,
   "files": [
     "./types/",


### PR DESCRIPTION
The "types" property of package.json was incorrectly `./type` not `./types`